### PR TITLE
Update Ghostscript version to 9.54.0

### DIFF
--- a/Makefile_gs
+++ b/Makefile_gs
@@ -10,9 +10,9 @@ init:
 
 
 ## GHOSTSCRIPT (https://www.ghostscript.com/)
-## https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/ghostscript-9.27.tar.gz
+## https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0.tar.gz
 ## -------------------------------------------------------------------------------------------------------
-GHOSTSCRIPT_VERSION=9.27
+GHOSTSCRIPT_VERSION=9.54.0
 GHOSTSCRIPT_VERSION_DIR=gs$(subst .,,$(GHOSTSCRIPT_VERSION))
 GHOSTSCRIPT_SRC_FILE=ghostscript-${GHOSTSCRIPT_VERSION}.tar.gz
 GHOSTSCRIPT_SRC_DIR=$(subst .tar.gz,,$(GHOSTSCRIPT_SRC_FILE))

--- a/Makefile_gs
+++ b/Makefile_gs
@@ -10,9 +10,9 @@ init:
 
 
 ## GHOSTSCRIPT (https://www.ghostscript.com/)
-## https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0.tar.gz
+## https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9561/ghostscript-9.56.1.tar.gz
 ## -------------------------------------------------------------------------------------------------------
-GHOSTSCRIPT_VERSION=9.54.0
+GHOSTSCRIPT_VERSION=9.56.1
 GHOSTSCRIPT_VERSION_DIR=gs$(subst .,,$(GHOSTSCRIPT_VERSION))
 GHOSTSCRIPT_SRC_FILE=ghostscript-${GHOSTSCRIPT_VERSION}.tar.gz
 GHOSTSCRIPT_SRC_DIR=$(subst .tar.gz,,$(GHOSTSCRIPT_SRC_FILE))

--- a/README-SAR.md
+++ b/README-SAR.md
@@ -1,7 +1,7 @@
 # Ghostscript Lambda Layer for Amazon Linux 2 AMIs
 
 Ghostscript AWS Lambda layer adding PDF files conversion support using ImageMagick.
-Bundles Ghostscript 9.54.0.
+Bundles Ghostscript 9.56.1.
 
 As a prerequisite, add the ImageMagick support by deploying the
 [image-magick-lambda-layer](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer)

--- a/README-SAR.md
+++ b/README-SAR.md
@@ -1,7 +1,7 @@
 # Ghostscript Lambda Layer for Amazon Linux 2 AMIs
 
 Ghostscript AWS Lambda layer adding PDF files conversion support using ImageMagick.
-Bundles Ghostscript 9.27.
+Bundles Ghostscript 9.54.0.
 
 As a prerequisite, add the ImageMagick support by deploying the
 [image-magick-lambda-layer](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modify the versions of libraries or Ghostscript directly in [`Makefile_gs`](Make
 ### Compiled info
 
 ```
-ghostscript version 9.27
+ghostscript version 9.54.0
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Scripts to compile Ghostscript (gs) for AWS Lambda instances powered by Amazon Linux 2.x,
 such as the `nodejs10.x` runtime, and the updated 2018.03 Amazon Linux 1 runtimes.
 
-
 ## Usage
 
 Absolutely the easiest way of using this is to pull it directly from the AWS Serverless
@@ -16,33 +15,31 @@ application in the Serverless App Repository.
 
 For manual deployments and custom builds, read below...
 
-
 ## Prerequisites
 
-  * Docker desktop
-  * Unix Make environment
-  * AWS command line utilities (just for deployment)
-
+- Docker desktop
+- Unix Make environment
+- AWS command line utilities (just for deployment)
 
 ## Compiling the code
 
-  * start Docker services
-  * `make all`
+- start Docker services
+- `make all`
 
 There are two `make` scripts in this project.
 
-  * [`Makefile`](Makefile) is intended to run on the build system, and just starts
-    a Docker container matching the AWS Linux 2 environment for Lambda runtimes to
-    compile Ghostscript using the second script.
-  * [`Makefile_gs`](Makefile_gs) is the script that will run inside the container,
-    and actually compile binaries. 
+- [`Makefile`](Makefile) is intended to run on the build system, and just starts
+  a Docker container matching the AWS Linux 2 environment for Lambda runtimes to
+  compile Ghostscript using the second script.
+- [`Makefile_gs`](Makefile_gs) is the script that will run inside the container,
+  and actually compile binaries.
 
 The output will be in the `result` dir.
 
 ### Configuring the build
 
 By default, this compiles a version expecting to run as a Lambda layer from
-`/opt`. You can change the expected location by providing a `TARGET` variable 
+`/opt`. You can change the expected location by providing a `TARGET` variable
 when invoking `make`.
 
 The default Docker image used is `lambci/lambda-base-2:build`. To use a different
@@ -50,13 +47,11 @@ base, provide a `DOCKER_IMAGE` variable when invoking `make`.
 
 Modify the versions of libraries or Ghostscript directly in [`Makefile_gs`](Makefile_gs).
 
-
 ### Compiled info
 
 ```
-ghostscript version 9.54.0
+ghostscript version 9.56.1
 ```
-
 
 ## Deploying to AWS as a layer
 
@@ -66,27 +61,23 @@ Run the following command to deploy the compiled result as a layer in your AWS a
 make deploy DEPLOYMENT_BUCKET=<YOUR BUCKET NAME> [PROFILE="--profile <YOUR NAMED PROFILE FROM ~/.aws/credentials>"]
 ```
 
-
 ### Configuring the deployment
 
 By default, this uses `ghostscript-layer` as the stack name. Provide a
 `STACK_NAME` variable when calling `make deploy` to use an alternative name.
 
-
 ## Additional Info
 
 For more information, check out:
 
-  * https://www.ghostscript.com/
-
+- https://www.ghostscript.com/
 
 ## Author
 
 Tomislav Capan
 
-
 ## License
 
-  * These scripts: [MIT](https://opensource.org/licenses/MIT)
-  * Ghostscript: <https://www.ghostscript.com/license.html>
-  * Contained libraries all have separate licenses, check the respective web sites for more information
+- These scripts: [MIT](https://opensource.org/licenses/MIT)
+- Ghostscript: <https://www.ghostscript.com/license.html>
+- Contained libraries all have separate licenses, check the respective web sites for more information

--- a/template.yaml
+++ b/template.yaml
@@ -31,12 +31,12 @@ Metadata:
     Name: ghostscript-lambda-layer
     Description: >
       Ghostscript AWS Lambda layer adding PDF files conversion support using ImageMagick.
-      Bundles Ghostscript 9.27.
+      Bundles Ghostscript 9.54.0.
     Author: Tomislav Capan
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README-SAR.md
     Labels: ['layer', 'pdf', 'lambda', 'ghostscript', 'gs']
     HomePageUrl: https://github.com/zappan/ghostscript-lambda-layer
-    SemanticVersion: 9.27.0
+    SemanticVersion: 9.54.0
     SourceCodeUrl: https://github.com/zappan/ghostscript-lambda-layer

--- a/template.yaml
+++ b/template.yaml
@@ -31,12 +31,12 @@ Metadata:
     Name: ghostscript-lambda-layer
     Description: >
       Ghostscript AWS Lambda layer adding PDF files conversion support using ImageMagick.
-      Bundles Ghostscript 9.54.0.
+      Bundles Ghostscript 9.56.1.
     Author: Tomislav Capan
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README-SAR.md
     Labels: ['layer', 'pdf', 'lambda', 'ghostscript', 'gs']
     HomePageUrl: https://github.com/zappan/ghostscript-lambda-layer
-    SemanticVersion: 9.54.0
+    SemanticVersion: 9.56.1
     SourceCodeUrl: https://github.com/zappan/ghostscript-lambda-layer


### PR DESCRIPTION
Hi @zappan! First: Thanks for sharing these scripts to create Ghostscript Lambda Layers. It's very handy!
But it uses an old version of Ghostscript (9.27) that contains a critical security vulnerability. This vulnerability is actively exploited in the wild since almost ~2 years: https://nvd.nist.gov/vuln/detail/CVE-2019-10216

In the case of this layer, It allows attackers to completely compromise the Lambda container by uploading EPS files containing malicious scripts.

Please update the related [Lambda Layer](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:154387959412:applications~ghostscript-lambda-layer) at AWS Serverless Application Repository, so at least new deployments aren't affected by this flaw anymore.

All credits go to @jensvoid who found and reported this vulnerability in a service using this Lamdba Layer.